### PR TITLE
fix(MapCard): scale

### DIFF
--- a/src/components/CivModal.astro
+++ b/src/components/CivModal.astro
@@ -171,7 +171,7 @@ const getProgressColor = (rating: number) => {
                   "h-3 rounded-full transition-all duration-500",
                   getProgressColor(rating)
                 ]}
-                style={`width: ${rating}%`}
+                style={`width: ${(rating - 80) * (100 / 20)}%`}
               ></div>
             </div>
             

--- a/src/components/mapCard.astro
+++ b/src/components/mapCard.astro
@@ -188,7 +188,7 @@ const modalId = `modal-${mapData._id}`;
                     "h-2 rounded-full transition-all duration-500",
                     getProgressColor(rating)
                   ]}
-                  style={`width: ${rating}%`}
+                  style={`width: ${(rating - 85) * (100 / 15)}%`}
                 ></div>
               </div>
             </div>


### PR DESCRIPTION
Cambie las escalas de las barras para que tengan mas sentido
Van de 85-100 para las top y de 80-100 para el CivModal
![image](https://github.com/user-attachments/assets/d0f3b04c-a26b-4d70-a475-98befcb4b1c4)
![image](https://github.com/user-attachments/assets/42dcdfb7-689f-421d-bbd5-14ff8accee53)
